### PR TITLE
Also add steps for building and pushing the docker image. 

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,21 +43,23 @@ jobs:
           else
             echo "No new release was created"
           fi    
-  
-  # automerge-version-pull-request:
-  #   runs-on: ubuntu-latest
-  #   needs: release-please
-  #   steps:
-  #     - id: automerge
-  #       name: automerge
-  #       uses: "pascalgn/automerge-action@v0.15.6"
-  #       env:
-  #         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  #         MERGE_LABELS: "automerge, autorelease:pending"
-  #         MERGE_REMOVE_LABELS: "automerge, autorelease:pending"
-  #     - name: feedback
-  #       if: ${{ steps.automerge.outputs.mergeResult == 'merged' }}
-  #       run: |
-  #         echo "Pull request ${{ steps.automerge.outputs.pullRequestNumber }} merged!"
-    
-    
+          
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: ${{ secrets.DOCKER_USERNAME }}/image-name:${{ needs.release-please.outputs.version }}
+          


### PR DESCRIPTION
This workflow will fail now since no Docker credentials are set in the repository's secrets. To make this workflow work correctly they need to be added.